### PR TITLE
STF-2926 Promotion cards API documentaion fix

### DIFF
--- a/source/includes/_promotion_cards.md.erb
+++ b/source/includes/_promotion_cards.md.erb
@@ -3,7 +3,7 @@
 ## Список промо баннеров
 
 ```shell
-curl "<%= config[:host] %>/promotion_cards/?sid=1"
+curl "<%= config[:host] %>/stores/#{sid}/promotion_cards/"
 ```
 
 > Команда выше возвращает JSON:
@@ -51,7 +51,7 @@ curl "<%= config[:host] %>/promotion_cards/?sid=1"
 
 Получить список промо-карт, которые могут быть показаны при текущем магазине, можно, выполнив запрос:
 
-`GET <%= config[:host] %>/promotion_cards/?sid=1`
+`GET <%= config[:host] %>/stores/#{sid}/promotion_cards`
 
 ### Параметры запроса
 

--- a/source/includes/_promotion_cards.md.erb
+++ b/source/includes/_promotion_cards.md.erb
@@ -3,7 +3,7 @@
 ## Список промо-карт
 
 ```shell
-curl "<%= config[:host] %>/promotion_cards"
+curl "<%= config[:host] %>/promotion_cards/?sid=1"
 ```
 
 > Команда выше возвращает JSON:
@@ -15,6 +15,7 @@ curl "<%= config[:host] %>/promotion_cards"
       "id": 41,
       "title": "название",
       "short_description": "короткое описание в одну фразу",
+      "short_description_widt": 200,
       "full_description": "полное описание, которое <b>может</b содержать HTML>",
       "background_color": "#000000",
       "text_color": "#FFFFFF",
@@ -31,6 +32,7 @@ curl "<%= config[:host] %>/promotion_cards"
       "id": 42,
       "title": "название",
       "short_description": "короткое описание в одну фразу",
+      "short_description_widt": 200,
       "full_description": "полное описание, которое <b>может</b содержать HTML>",
       "background_color": "#000000",
       "text_color": "#FFFFFF",
@@ -47,6 +49,13 @@ curl "<%= config[:host] %>/promotion_cards"
 }
 ```
 
-Получить список промо-карт можно, выполнив запрос:
+Получить список промо-карт, которые могут быть показаны при текущем магазине, можно, выполнив запрос:
 
-`GET <%= config[:host] %>/promotion_cards`
+`GET <%= config[:host] %>/promotion_cards/?sid=1`
+
+### Параметры запроса
+
+Параметр | Обязательный | Описание
+--------- | ------- | -----------
+sid | Да | Идентификатор магазина
+

--- a/source/includes/_promotion_cards.md.erb
+++ b/source/includes/_promotion_cards.md.erb
@@ -1,6 +1,6 @@
 # Промо-карточки
 
-## Список промо-карт
+## Список промо баннеров
 
 ```shell
 curl "<%= config[:host] %>/promotion_cards/?sid=1"
@@ -15,7 +15,7 @@ curl "<%= config[:host] %>/promotion_cards/?sid=1"
       "id": 41,
       "title": "название",
       "short_description": "короткое описание в одну фразу",
-      "short_description_widt": 200,
+      "short_description_width": 200,
       "full_description": "полное описание, которое <b>может</b содержать HTML>",
       "background_color": "#000000",
       "text_color": "#FFFFFF",
@@ -32,7 +32,7 @@ curl "<%= config[:host] %>/promotion_cards/?sid=1"
       "id": 42,
       "title": "название",
       "short_description": "короткое описание в одну фразу",
-      "short_description_widt": 200,
+      "short_description_width": 200,
       "full_description": "полное описание, которое <b>может</b содержать HTML>",
       "background_color": "#000000",
       "text_color": "#FFFFFF",

--- a/source/includes/_promotions.md.erb
+++ b/source/includes/_promotions.md.erb
@@ -3,7 +3,7 @@
 ## Список продуктов обязательные для активации промоакции
 
 ```shell
-curl "<%= config[:host] %>/promotions/42/promotion_products?sid=1"
+curl "<%= config[:host] %>/promotions/42/promo_products?sid=1"
 ```
 
 > Команда выше возвращает JSON:
@@ -51,7 +51,7 @@ curl "<%= config[:host] %>/promotions/42/promotion_products?sid=1"
 
 ### HTTP запрос
 
-`GET <%= config[:host] %>/promotions/#{ID}/promotion_products?sid=1`
+`GET <%= config[:host] %>/promotions/#{ID}/promo_products?sid=1`
 
 
 ### Параметры запроса

--- a/source/includes/_promotions.md.erb
+++ b/source/includes/_promotions.md.erb
@@ -3,7 +3,7 @@
 ## Список продуктов обязательные для активации промоакции
 
 ```shell
-curl "<%= config[:host] %>/promotions/42/mandatory_products?sid=1"
+curl "<%= config[:host] %>/promotions/42/promotion_products?sid=1"
 ```
 
 > Команда выше возвращает JSON:
@@ -51,7 +51,7 @@ curl "<%= config[:host] %>/promotions/42/mandatory_products?sid=1"
 
 ### HTTP запрос
 
-`GET <%= config[:host] %>/promotions/#{ID}/mandatory_products?sid=1`
+`GET <%= config[:host] %>/promotions/#{ID}/promotion_products?sid=1`
 
 
 ### Параметры запроса


### PR DESCRIPTION
[Jira](https://instamart.atlassian.net/browse/STF-2926)

- `mandatory_products` → `promotion_products`
- `promotion_cards` requires `:sid` parameter now
- `/promotion_cards?sid=#{sid}` -> `stores/#{sid}/promotion_cards`